### PR TITLE
feat: 검색한 키워드가 포함된 문장UI 표시

### DIFF
--- a/src/components/ExtensionContent.jsx
+++ b/src/components/ExtensionContent.jsx
@@ -8,7 +8,7 @@ import ExtensionTopContent from "./extensionTopContent/extensionTopContent";
 function ExtensionContent({ urlNewList }) {
   const [bookmarkList, setBookmarkList] = useState([]);
   const [searchKeyword, setSearchKeyword] = useState("");
-  const [setKeyword, isLoading, error] = useFetchUrlContent(
+  const [keyword, setKeyword, isLoading, error] = useFetchUrlContent(
     setBookmarkList,
     urlNewList
   );
@@ -25,6 +25,7 @@ function ExtensionContent({ urlNewList }) {
         bookmarkList,
         setBookmarkList,
         handleStartSearch,
+        keyword,
         searchKeyword,
         setSearchKeyword,
       }}

--- a/src/components/extensionBottomContent/ExtensionBottomContent.jsx
+++ b/src/components/extensionBottomContent/ExtensionBottomContent.jsx
@@ -34,7 +34,7 @@ function UrlBox() {
               </a>
             </div>
             {url.urlText && <hr className="ml-3 w-[95%]" />}
-            <HighlightKeyword url={url} />
+            {url.urlText && <HighlightKeyword url={url} />}
           </>
         );
       })}
@@ -56,27 +56,25 @@ function HighlightKeyword({ url }) {
   return (
     <div
       className={
-        url.urlText &&
         "ml-3 mt-1 mb-2 font-normal w-full max-w-[calc(100%-0px)] overflow-hidden text-ellipsis whitespace-nowrap"
       }
     >
-      {url.urlText &&
-        url.urlText.split(keyword).map((item, index) => {
-          if (index === 0 && !item) {
-            return null;
-          } else if (index === 0 && item) {
-            return <span key={index}>{item}</span>;
-          } else {
-            return (
-              <span key={index}>
-                <span className="bg-blue-800 rounded-lg px-1 inline-block text-white mx-px">
-                  {keyword}
-                </span>
-                {item}
+      {url.urlText.split(keyword).map((item, index) => {
+        if (index === 0 && !item) {
+          return null;
+        } else if (index === 0 && item) {
+          return <span key={index}>{item}</span>;
+        } else {
+          return (
+            <span key={index}>
+              <span className="bg-blue-800 rounded-lg px-1 inline-block text-white mx-px">
+                {keyword}
               </span>
-            );
-          }
-        })}
+              {item}
+            </span>
+          );
+        }
+      })}
     </div>
   );
 }

--- a/src/components/extensionBottomContent/ExtensionBottomContent.jsx
+++ b/src/components/extensionBottomContent/ExtensionBottomContent.jsx
@@ -16,22 +16,26 @@ function UrlBox() {
     <li className="h-4">
       {bookmarkList.map((url, index) => {
         return (
-          <div
-            className="p-3 bg-white hover:bg-gray-200 flex items-center"
-            key={index}
-          >
-            <a
-              className="max-w-[calc(100%-10px)] flex-grow overflow-hidden text-ellipsis whitespace-nowrap"
-              href={`${url.url}`}
-              target="_blank"
+          <>
+            <div
+              className="p-3 bg-white hover:bg-gray-200 flex items-center"
+              key={index}
             >
-              <img
-                className="mr-2 inline-block w-3 h-3"
-                src={faviconURL(url.url)}
-              />
-              {url.title}
-            </a>
-          </div>
+              <a
+                className="max-w-[calc(100%-10px)] flex-grow overflow-hidden text-ellipsis whitespace-nowrap"
+                href={`${url.url}`}
+                target="_blank"
+              >
+                <img
+                  className="mr-2 inline-block w-3 h-3"
+                  src={faviconURL(url.url)}
+                />
+                {url.title}
+              </a>
+            </div>
+            {url.urlText && <hr className="ml-3 w-[95%]" />}
+            <HighlightKeyword url={url} />
+          </>
         );
       })}
     </li>
@@ -43,5 +47,36 @@ export default function ExtensionBottomContent() {
     <ul className="mt-[7rem] overflow-y-scroll h-[calc(100vh-7rem)]">
       <UrlBox />
     </ul>
+  );
+}
+
+function HighlightKeyword({ url }) {
+  const { keyword } = useContext(ExtensionContext);
+
+  return (
+    <div
+      className={
+        url.urlText &&
+        "ml-3 mt-1 mb-2 font-normal w-full max-w-[calc(100%-0px)] overflow-hidden text-ellipsis whitespace-nowrap"
+      }
+    >
+      {url.urlText &&
+        url.urlText.split(keyword).map((item, index) => {
+          if (index === 0 && !item) {
+            return null;
+          } else if (index === 0 && item) {
+            return <span key={index}>{item}</span>;
+          } else {
+            return (
+              <span key={index}>
+                <span className="bg-blue-800 rounded-lg px-1 inline-block text-white mx-px">
+                  {keyword}
+                </span>
+                {item}
+              </span>
+            );
+          }
+        })}
+    </div>
   );
 }

--- a/src/hooks/useFetchUrlContent.js
+++ b/src/hooks/useFetchUrlContent.js
@@ -68,7 +68,7 @@ const useFetchUrlContent = (setCrawledResult, savedList) => {
     getCrawledData();
   }, [getCrawledData]);
 
-  return [setKeyword, isLoading, error];
+  return [keyword, setKeyword, isLoading, error];
 };
 
 export default useFetchUrlContent;


### PR DESCRIPTION
### 어떤 PR유형인가요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 작업 내용을 요약해주세요
검색한 결과 속 키워드가 포함된 문장[urlText]를 title밑으로 표시하고 검색한 키워드에 대해 UI표시를 진행했습니다.
원래 [익스텐션 키워드 검색 API ](https://github.com/ECMA-393/UrLink-Extension/issues/1)에 포함되어 있는 부분이었으나 키워드 포함 문장을 추출하는 작업 진행상황에 맞춰 추후 다시 올리게 되었습니다.


### 구현 사진
<img width="464" alt="스크린샷 2025-02-01 오후 6 23 35" src="https://github.com/user-attachments/assets/fc02ebfc-994d-447b-9d82-1f659347e755" />

