### PR TITLE
feat: 검색 시 제목 또는 제목 + 키워드 결과도 볼 수 있도록 검색 기능추가 구현

### DIFF
--- a/options/components/WebContnet.jsx
+++ b/options/components/WebContnet.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { SELECT_VALUE_STATE } from "../constants/selectValueState";
 import { WebSearchContext } from "../context/WebSearchContext";
 import useFetchKeywordSearchList from "../hooks/useFetchKeywordSearchData";
 import WebBottomContent from "./webBottomContent/WebBottomContent";
@@ -7,6 +8,9 @@ import WebTopContent from "./webTopContent/WebTopContent";
 
 function WebContent({ urlNewList }) {
   const [searchKeyword, setSearchKeyword] = useState("");
+  const [userSelectSearchValue, setUserSelectSearchValue] = useState(
+    SELECT_VALUE_STATE[0]
+  );
   const [bookmarkList, setBookmarkList] = useState([]);
   const [
     setKeyword,
@@ -16,7 +20,12 @@ function WebContent({ urlNewList }) {
     hasSearchResult,
     setHasSearchResult,
     keyword,
-  ] = useFetchKeywordSearchList(setBookmarkList, setSearchKeyword, urlNewList);
+  ] = useFetchKeywordSearchList(
+    setBookmarkList,
+    setSearchKeyword,
+    urlNewList,
+    userSelectSearchValue
+  );
 
   chrome.storage.onChanged.addListener((changes) => {
     for (const [key, { newValue }] of Object.entries(changes)) {
@@ -59,12 +68,15 @@ function WebContent({ urlNewList }) {
     <div className="w-full h-dvh bg-gray-200">
       <WebSearchContext.Provider
         value={{
+          SELECT_VALUE_STATE,
           bookmarkList,
           setBookmarkList,
           searchKeyword,
           setSearchKeyword,
           handleStartSearch,
           handleOnClickReset,
+          setUserSelectSearchValue,
+          userSelectSearchValue,
           hasSearchResult,
           setHasSearchResult,
           isLoading,

--- a/options/components/webBottomContent/WebBottomContent.jsx
+++ b/options/components/webBottomContent/WebBottomContent.jsx
@@ -11,8 +11,13 @@ export default function WebBottomContent() {
 }
 
 function WebUrlNewList() {
-  const { bookmarkList, hasSearchResult, keyword, userSelectSearchValue } =
-    useContext(WebSearchContext);
+  const {
+    bookmarkList,
+    hasSearchResult,
+    keyword,
+    userSelectSearchValue,
+    SELECT_VALUE_STATE,
+  } = useContext(WebSearchContext);
 
   function faviconURL(u) {
     const url = new URL(chrome.runtime.getURL("/_favicon/"));
@@ -39,15 +44,15 @@ function WebUrlNewList() {
             />
             {hasSearchResult &&
             keyword &&
-            userSelectSearchValue === "키워드 검색" ? (
+            userSelectSearchValue === SELECT_VALUE_STATE[0] ? (
               <HighlightKeyword url={url} />
             ) : hasSearchResult &&
               keyword &&
-              userSelectSearchValue === "제목 검색" ? (
+              userSelectSearchValue === SELECT_VALUE_STATE[1] ? (
               <HighlightTitleKeyword url={url} />
             ) : hasSearchResult &&
               keyword &&
-              userSelectSearchValue === "제목 + 키워드 검색" ? (
+              userSelectSearchValue === SELECT_VALUE_STATE[2] ? (
               <HighlightKeyword url={url} />
             ) : (
               url.title
@@ -60,11 +65,12 @@ function WebUrlNewList() {
 }
 
 function HighlightKeyword({ url }) {
-  const { keyword, userSelectSearchValue } = useContext(WebSearchContext);
+  const { keyword, userSelectSearchValue, SELECT_VALUE_STATE } =
+    useContext(WebSearchContext);
 
   return (
     <>
-      {userSelectSearchValue === "제목 + 키워드 검색" ? (
+      {userSelectSearchValue === SELECT_VALUE_STATE[2] ? (
         <HighlightTitleKeyword url={url} />
       ) : (
         url.title
@@ -75,7 +81,7 @@ function HighlightKeyword({ url }) {
             return null;
           } else if (index === 0 && item) {
             return <span key={index}>{item}</span>;
-          } else if (index === 1 && item) {
+          } else {
             return (
               <span key={index}>
                 <span className="bg-blue-800 rounded-lg px-1 inline-block text-white mx-px">
@@ -101,7 +107,7 @@ function HighlightTitleKeyword({ url }) {
           return null;
         } else if (index === 0 && item) {
           return <span key={index}>{item}</span>;
-        } else if (index === 1 && item) {
+        } else {
           return (
             <span key={index}>
               <span className="text-blue-600 font-bold px-1 inline-block mx-px">

--- a/options/components/webBottomContent/WebBottomContent.jsx
+++ b/options/components/webBottomContent/WebBottomContent.jsx
@@ -11,7 +11,8 @@ export default function WebBottomContent() {
 }
 
 function WebUrlNewList() {
-  const { bookmarkList, hasSearchResult } = useContext(WebSearchContext);
+  const { bookmarkList, hasSearchResult, keyword, userSelectSearchValue } =
+    useContext(WebSearchContext);
 
   function faviconURL(u) {
     const url = new URL(chrome.runtime.getURL("/_favicon/"));
@@ -36,8 +37,21 @@ function WebUrlNewList() {
               className="mr-2 inline-block w-3 h-3"
               src={faviconURL(url.url)}
             />
-            {url.title}
-            {hasSearchResult ? <HighlightKeyword url={url} /> : ""}
+            {hasSearchResult &&
+            keyword &&
+            userSelectSearchValue === "키워드 검색" ? (
+              <HighlightKeyword url={url} />
+            ) : hasSearchResult &&
+              keyword &&
+              userSelectSearchValue === "제목 검색" ? (
+              <HighlightTitleKeyword url={url} />
+            ) : hasSearchResult &&
+              keyword &&
+              userSelectSearchValue === "제목 + 키워드 검색" ? (
+              <HighlightKeyword url={url} />
+            ) : (
+              url.title
+            )}
           </a>
         </div>
       ))}
@@ -46,12 +60,17 @@ function WebUrlNewList() {
 }
 
 function HighlightKeyword({ url }) {
-  const { keyword } = useContext(WebSearchContext);
+  const { keyword, userSelectSearchValue } = useContext(WebSearchContext);
 
   return (
-    <div className="mt-3 pt-3 border-t font-normal w-full max-w-[calc(100%-0px)] overflow-hidden text-ellipsis whitespace-nowrap">
-      {url.urlText.includes(keyword) &&
-        url.urlText.split(keyword).map((item, index) => {
+    <>
+      {userSelectSearchValue === "제목 + 키워드 검색" ? (
+        <HighlightTitleKeyword url={url} />
+      ) : (
+        url.title
+      )}
+      <div className="mt-3 pt-3 border-t font-normal w-full max-w-[calc(100%-0px)] overflow-hidden text-ellipsis whitespace-nowrap">
+        {url.urlText.split(keyword).map((item, index) => {
           if (index === 0 && !item) {
             return null;
           } else if (index === 0 && item) {
@@ -67,6 +86,32 @@ function HighlightKeyword({ url }) {
             );
           }
         })}
-    </div>
+      </div>
+    </>
+  );
+}
+
+function HighlightTitleKeyword({ url }) {
+  const { keyword } = useContext(WebSearchContext);
+
+  return (
+    <>
+      {url.title.split(keyword).map((item, index) => {
+        if (index === 0 && !item) {
+          return null;
+        } else if (index === 0 && item) {
+          return <span key={index}>{item}</span>;
+        } else if (index === 1 && item) {
+          return (
+            <span key={index}>
+              <span className="text-blue-600 font-bold px-1 inline-block mx-px">
+                {keyword}
+              </span>
+              {item}
+            </span>
+          );
+        }
+      })}
+    </>
   );
 }

--- a/options/components/webTopContent/WebTopContent.jsx
+++ b/options/components/webTopContent/WebTopContent.jsx
@@ -2,15 +2,10 @@ import WebGlobalNavigationBar from "./top-contents/WebGlobalNavigationBar";
 import WebKeywordSearchBox from "./top-contents/WebKeywordSearchBox";
 
 export default function WebTopContent({ urlNewList }) {
-  const selectValueTypes = ["키워드 검색", "제목 검색", "제목 + 키워드 검색"];
-
   return (
     <div className="w-full lg:max-w-5xl lg:px-0 md:max-w-screen-md sm:max-w-screen-sm px-2 pt-5 pb-[14px] mx-auto my-0">
       <WebGlobalNavigationBar urlNewList={urlNewList} />
-      <WebKeywordSearchBox
-        urlNewList={urlNewList}
-        selectData={selectValueTypes}
-      />
+      <WebKeywordSearchBox urlNewList={urlNewList} />
     </div>
   );
 }

--- a/options/components/webTopContent/top-contents/WebKeywordSearchBox.jsx
+++ b/options/components/webTopContent/top-contents/WebKeywordSearchBox.jsx
@@ -4,15 +4,19 @@ import { useContext, useState } from "react";
 
 import { WebSearchContext } from "../../../context/WebSearchContext";
 
-export default function WebKeywordSearchBox({ selectData, urlNewList }) {
-  const [currentSelectValue, setCurrentSelectValue] = useState(selectData[0]);
+export default function WebKeywordSearchBox({ urlNewList }) {
+  const {
+    userSelectSearchValue,
+    setUserSelectSearchValue,
+    SELECT_VALUE_STATE,
+  } = useContext(WebSearchContext);
 
   return (
     <div className="flex">
       <WebSelectBox
-        selectData={selectData}
-        setCurrentSelectValue={setCurrentSelectValue}
-        currentSelectValue={currentSelectValue}
+        selectData={SELECT_VALUE_STATE}
+        setUserSelectSearchValue={setUserSelectSearchValue}
+        userSelectSearchValue={userSelectSearchValue}
       />
       <WebSearchBox urlNewList={urlNewList} />
     </div>
@@ -21,8 +25,8 @@ export default function WebKeywordSearchBox({ selectData, urlNewList }) {
 
 function WebSelectBox({
   selectData,
-  setCurrentSelectValue,
-  currentSelectValue,
+  setUserSelectSearchValue,
+  userSelectSearchValue,
 }) {
   const [isShowOptions, setIsShowOptions] = useState(false);
 
@@ -32,7 +36,7 @@ function WebSelectBox({
 
   const handleOnChangeSelectValue = (event) => {
     const { innerText } = event.target;
-    setCurrentSelectValue(innerText);
+    setUserSelectSearchValue(innerText);
   };
 
   return (
@@ -42,7 +46,7 @@ function WebSelectBox({
       }
       onClick={() => handleOnChangeSelectToggle()}
     >
-      <label className=" text-sm leading-10">{currentSelectValue}</label>
+      <label className=" text-sm leading-10">{userSelectSearchValue}</label>
       <div
         className={
           isShowOptions === false

--- a/options/constants/selectValueState.js
+++ b/options/constants/selectValueState.js
@@ -1,0 +1,5 @@
+export const SELECT_VALUE_STATE = [
+  "키워드 검색",
+  "제목 검색",
+  "제목 + 키워드 검색",
+];

--- a/options/hooks/useFetchKeywordSearchData.js
+++ b/options/hooks/useFetchKeywordSearchData.js
@@ -5,7 +5,8 @@ import { SERVER_URL } from "../constants/constants";
 const useFetchKeywordSearchList = (
   setCrawledResult,
   setSearchKeyword,
-  bookmarkList
+  bookmarkList,
+  userSelectValue
 ) => {
   const [keyword, setKeyword] = useState("");
   const [hasSearchResult, setHasSearchResult] = useState(false);
@@ -17,10 +18,20 @@ const useFetchKeywordSearchList = (
       const fetchEncodedUrlList = bookmarkList.map((bookmark) => {
         const encodedUrl = encodeURIComponent(bookmark.url);
 
-        if (keyword) {
+        if (keyword && userSelectValue === "키워드 검색") {
           setHasSearchResult(true);
           return fetch(
             `${SERVER_URL}/crawl/${encodedUrl}/search?keyword=${keyword}`
+          );
+        } else if (keyword && userSelectValue === "제목 검색") {
+          setHasSearchResult(true);
+          return fetch(
+            `${SERVER_URL}/crawl/title/${encodedUrl}/search?keyword=${keyword}`
+          );
+        } else if (keyword && userSelectValue === "제목 + 키워드 검색") {
+          setHasSearchResult(true);
+          return fetch(
+            `${SERVER_URL}/crawl/all/${encodedUrl}/search?keyword=${keyword}`
           );
         } else {
           setIsLoading(false);
@@ -77,7 +88,13 @@ const useFetchKeywordSearchList = (
     } catch (error) {
       setError(error);
     }
-  }, [keyword, bookmarkList, setCrawledResult, setSearchKeyword]);
+  }, [
+    keyword,
+    bookmarkList,
+    setCrawledResult,
+    setSearchKeyword,
+    userSelectValue,
+  ]);
 
   useEffect(() => {
     setIsLoading(true);

--- a/options/hooks/useFetchKeywordSearchData.js
+++ b/options/hooks/useFetchKeywordSearchData.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { SERVER_URL } from "../constants/constants";
+import { SELECT_VALUE_STATE } from "../constants/selectValueState";
 
 const useFetchKeywordSearchList = (
   setCrawledResult,
@@ -18,21 +19,20 @@ const useFetchKeywordSearchList = (
       const fetchEncodedUrlList = bookmarkList.map((bookmark) => {
         const encodedUrl = encodeURIComponent(bookmark.url);
 
-        if (keyword && userSelectValue === "키워드 검색") {
+        if (keyword) {
+          let url = "";
+          if (userSelectValue === SELECT_VALUE_STATE[0]) {
+            url = `${SERVER_URL}/crawl/${encodedUrl}/search?keyword=${keyword}`;
+          }
+          if (userSelectValue === SELECT_VALUE_STATE[1]) {
+            url = `${SERVER_URL}/crawl/title/${encodedUrl}/search?keyword=${keyword}`;
+          }
+          if (userSelectValue === SELECT_VALUE_STATE[2]) {
+            url = `${SERVER_URL}/crawl/all/${encodedUrl}/search?keyword=${keyword}`;
+          }
+
           setHasSearchResult(true);
-          return fetch(
-            `${SERVER_URL}/crawl/${encodedUrl}/search?keyword=${keyword}`
-          );
-        } else if (keyword && userSelectValue === "제목 검색") {
-          setHasSearchResult(true);
-          return fetch(
-            `${SERVER_URL}/crawl/title/${encodedUrl}/search?keyword=${keyword}`
-          );
-        } else if (keyword && userSelectValue === "제목 + 키워드 검색") {
-          setHasSearchResult(true);
-          return fetch(
-            `${SERVER_URL}/crawl/all/${encodedUrl}/search?keyword=${keyword}`
-          );
+          return fetch(url);
         } else {
           setIsLoading(false);
           const storageBookMarkList = chrome.storage.session.get([


### PR DESCRIPTION
### 어떤 PR유형인가요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 작업 내용을 요약해주세요
- select 박스의 선택지에 따라 받아 볼 수 있는 결과가 다르도록 구현하였습니다.
  - 제목 검색 : 사용자가 등록한 북마크 명을 기준으로 검색할 수 있도록 구현하였습니다.
  - 제목 + 키워드 검색: 사용자가 등록한 북마크 명 + url 안의 키워드가 보여질 수 있도록 구현하였습니다.
- 선택 된 키워드 하이라이팅 처리 컬러(파란색)은 임의이므로 참고 부탁드립니다.

### 어떻게 보완하면 좋을까요?
- select 내용 구현 시 배열의 인덱스 넘버로 구현하고 싶었으나 로직 상 의도하지 않게 current 된 innerText 값을 받아오게 되어 로직이 조금 더 길어져 가독성이 떨어진다고 느껴졌습니다. 여유가 된다면 인덱스 넘버로 구현 할 수 있도록 리팩토링 하고자 합니다.

### 집중적으로 받고 싶은 피드백은 무엇인가요?

- 코드 컨벤션 또는 컴포넌트 재사용성에 대하여 피드백 해주신다면 감사할 것 같습니다.
