### PR TITLE
fix: chrome API가 중첩되어 발생하던 버그를 해결 & 오타 수정

### DIFF
--- a/options/components/WebContnet.jsx
+++ b/options/components/WebContnet.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { SELECT_VALUE_STATE } from "../constants/selectValueState";
 import { WebSearchContext } from "../context/WebSearchContext";
@@ -27,28 +27,30 @@ function WebContent({ urlNewList }) {
     userSelectSearchValue
   );
 
-  chrome.storage.onChanged.addListener((changes) => {
-    for (const [key, { newValue }] of Object.entries(changes)) {
-      if (key === "webBookmarkList") {
-        setBookmarkList(newValue.searchResultList);
-        setSearchKeyword(newValue.keyword);
-        break;
-      }
+  useEffect(() => {
+    chrome.storage.onChanged.addListener((changes) => {
+      for (const [key, { newValue }] of Object.entries(changes)) {
+        if (key === "webBookmarkList") {
+          setBookmarkList(newValue.searchResultList);
+          setSearchKeyword(newValue.keyword);
+          break;
+        }
 
-      if (key === "webIsLoading") {
-        setIsLoading(newValue);
-        break;
+        if (key === "webIsLoading") {
+          setIsLoading(newValue);
+          break;
+        }
       }
-    }
-  });
+    });
 
-  const webSearchedList = chrome.storage.session.get(["webBookmarkList"]);
-  webSearchedList.then((list) => {
-    if (Object.keys(list).length !== 0) {
-      setBookmarkList(list.webBookmarkList.searchResultList);
-      setSearchKeyword(list.bookwebBookmarkListmarkList.keyword);
-    }
-  });
+    const webSearchedList = chrome.storage.session.get(["webBookmarkList"]);
+    webSearchedList.then((list) => {
+      if (Object.keys(list).length !== 0) {
+        setBookmarkList(list.webBookmarkList.searchResultList);
+        setSearchKeyword(list.webBookmarkList.keyword);
+      }
+    });
+  }, [setIsLoading]);
 
   const handleStartSearch = () => {
     if (!isLoading) {


### PR DESCRIPTION
### 어떤 PR유형인가요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 작업 내용을 요약해주세요
#19 해당 이슈 버그
검색을 여러번 진행 시 진행 때 마다 chrome API 이벤트 리스너가 중복되어 점점 렉이 걸리던 문제를 발견하여 해당 문제를 해결했습니다.
useEffect를 사용해 이벤트 리스너 등록 횟수에 제한을 걸어주었고 
기존 발견하지 못했던 오타를 수정했습니다.

### 어떻게 보완하면 좋을까요?
검색 로직과 커스텀 훅 개선으로 useEffect의 사용횟수를 최소한으로 줄이고 싶습니다.

### 집중적으로 받고 싶은 피드백은 무엇인가요?
오타 혹은 컨벤션에 대해 집중적으로 받고 싶습니다.
