### PR TITLE
refactor: 북마크 가져오는 로직 비재귀적 함수로 변경, 로컬스토리지 저장 북마크 변경

### DIFF
--- a/src/hooks/useBookmarks.js
+++ b/src/hooks/useBookmarks.js
@@ -4,25 +4,26 @@ const useBookmarks = () => {
   const [bookmarkList, setBookmarkList] = useState([]);
 
   useEffect(() => {
-    const getAllBookmark = (nodeItems) => {
+    function getAllBookmark(nodeItems) {
       const newBookmarkList = [];
+      const stack = [...nodeItems];
 
-      function recursive(node) {
+      while (stack.length) {
+        const node = stack.pop();
         if (Array.isArray(node)) {
-          node.forEach((item) => recursive(item));
+          stack.push(...node);
         } else if (typeof node === "object" && node !== null) {
           if (node.children) {
-            recursive(node.children);
+            stack.push(...node.children);
           }
           if (node.title && node.url) {
             newBookmarkList.push(node);
           }
         }
-        return newBookmarkList;
       }
 
-      setBookmarkList(recursive(nodeItems));
-    };
+      setBookmarkList(newBookmarkList);
+    }
 
     chrome.bookmarks.getTree((treeList) => {
       getAllBookmark(treeList);

--- a/src/hooks/useFetchUrlContent.js
+++ b/src/hooks/useFetchUrlContent.js
@@ -59,7 +59,10 @@ const useFetchUrlContent = () => {
             for (let i = 0; i < allBookmarkList.length; i++) {
               if (allBookmarkList[i].url === bookmarkItem.url) {
                 bookmarkAllInnerText.push({
-                  [`${bookmarkItem.url}`]: bookmarkItem,
+                  [`${bookmarkItem.url}`]: {
+                    ...bookmarkItem,
+                    ...allBookmarkList[i],
+                  },
                 });
 
                 return { ...bookmarkItem, ...allBookmarkList[i] };


### PR DESCRIPTION
### 어떤 PR유형인가요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 작업 내용을 요약해주세요
로컬 스토리지에 북마크 정보를 저장 시 제목도 함께 저장되도록 변경했습니다.
재귀함수를 사용해 북마크를 가져오던 부분을 비재귀적으로 while을 사용해 가져오도록 변경했습니다.

작업 이유 : 재귀 함수는 콜 스택에 계속해서 중첩되기 때문에 보다 좋은 선택지라고 생각되어 다음과 같이 while을 사용해 비재귀적으로 리팩토링 진행해 보았습니다.

### 어떻게 보완하면 좋을까요?

### 집중적으로 받고 싶은 피드백은 무엇인가요?

- while을 통해 비재귀적 함수를 만들었는데 해당 부분 기존 로직과 큰 차이점이 없는지 확인해주시면 감사하겠습니다.
