### PR TITLE
feat: select태그 li,ul사용한 커스텀 select로 변경 및 각 검색모드별 설명문 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react";
 
 import ExtensionContent from "./components/ExtensionContent";
+import { SEARCH_MODE } from "./constants/constants";
 import ExtensionContext from "./context/ExtensionContext";
 import useBookmarks from "./hooks/useBookmarks";
 
 function App() {
   const allBookmarkList = useBookmarks();
-  const [searchMode, setSearchMode] = useState("CONTENT");
+  const [searchMode, setSearchMode] = useState(SEARCH_MODE.CONTENT);
   const [searchKeyword, setSearchKeyword] = useState("");
   const [searchBookmarkList, setSearchBookmarkList] = useState([]);
 

--- a/src/components/extensionTopContent/top-contents/KeywordSearchBox.jsx
+++ b/src/components/extensionTopContent/top-contents/KeywordSearchBox.jsx
@@ -1,8 +1,12 @@
 import { faMagnifyingGlass, faRotate } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useContext } from "react";
+import { useContext, useState } from "react";
 
-import { SEARCH_MODE } from "../../../constants/constants";
+import {
+  MODE_DESCRIPTION,
+  MODE_EXPECT_CRAWLING_TIME,
+  SEARCH_MODE,
+} from "../../../constants/constants";
 import ExtensionContext from "../../../context/ExtensionContext";
 
 export default function KeywordSearchBox({
@@ -10,7 +14,9 @@ export default function KeywordSearchBox({
   inputKeyword,
   setInputKeyword,
 }) {
-  const { setSearchMode, setSearchKeyword } = useContext(ExtensionContext);
+  const [isSelectShow, setIsSelectShow] = useState(false);
+  const { allBookmarkList, searchMode, setSearchMode, setSearchKeyword } =
+    useContext(ExtensionContext);
 
   const handleInputKeyword = (event) => {
     if (isLoading) {
@@ -21,6 +27,10 @@ export default function KeywordSearchBox({
   };
 
   const handleEnterSearch = (event) => {
+    if (isLoading) {
+      return;
+    }
+
     if (event.key === "Enter") {
       setSearchKeyword(inputKeyword);
     }
@@ -36,22 +46,44 @@ export default function KeywordSearchBox({
   };
 
   const handleSearchModeChange = (event) => {
-    setSearchMode(event.currentTarget.value);
+    setSearchMode(event.currentTarget.dataset.mode);
     setSearchKeyword("");
   };
 
+  const handleToggleSelectBox = () => {
+    if (isLoading) {
+      return;
+    }
+
+    setIsSelectShow((isSelectShow) => !isSelectShow);
+  };
+
   return (
-    <div className="w-full h-10 rounded-full bg-white/[.5] text-white flex">
-      <select
-        defaultValue={SEARCH_MODE.CONTENT}
-        className="w-30 pl-4 bg-transparent h-10 text-sm placeholder-white grow outline-none"
-        onChange={handleSearchModeChange}
-        disabled={isLoading}
+    <div className="w-full h-10 rounded-full bg-[#808080] text-white flex">
+      <div
+        className="relative w-40 pl-4 bg-transparent flex items-center h-10 text-sm outline-none cursor-pointer"
+        onClick={handleToggleSelectBox}
       >
-        <option value={SEARCH_MODE.CONTENT}>내용</option>
-        <option value={SEARCH_MODE.TITLE}>제목</option>
-        <option value={SEARCH_MODE.ALL}>제목+내용</option>
-      </select>
+        <span className="w-[80%]">{searchMode}</span>
+        <span className="w-[20%]">&#9660;</span>
+        <ul
+          className={`${isSelectShow || "hidden"} absolute bg-black px-2 text-white bottom-[-200px] left-2`}
+        >
+          {Object.values(SEARCH_MODE).map((mode, index) => {
+            return (
+              <li
+                key={index}
+                className="w-full p-2 hover:bg-gray-500 inline-block whitespace-nowrap"
+                data-mode={mode}
+                onClick={handleSearchModeChange}
+              >
+                <p className="py-1">{mode}</p>
+                <p className="text-xs">{`${MODE_DESCRIPTION[mode]}${MODE_EXPECT_CRAWLING_TIME[mode] * allBookmarkList.length}초`}</p>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
       <input
         className="w-50 pl-4 bg-transparent h-10 text-sm placeholder-white grow outline-none"
         type="text"

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,19 +1,33 @@
 export const SERVER_URL = "http://localhost:3000/crawl";
 
 export const SEARCH_MODE = {
-  CONTENT: "CONTENT",
-  TITLE: "TITLE",
-  ALL: "ALL",
+  CONTENT: "내용",
+  TITLE: "제목",
+  ALL: "제목+내용",
+};
+
+export const MODE_DESCRIPTION = {
+  [SEARCH_MODE.CONTENT]: "문서 내부 내용을 검색합니다. | 예상소요시간 : ",
+  [SEARCH_MODE.TITLE]: "문서 제목을 검색합니다. | 예상소요시간 : ",
+  [SEARCH_MODE.ALL]: "문서 제목과 내부를 동시에 검색합니다. | 예상소요시간 : ",
+};
+
+export const MODE_EXPECT_CRAWLING_TIME = {
+  [SEARCH_MODE.CONTENT]: 5,
+  [SEARCH_MODE.TITLE]: 3,
+  [SEARCH_MODE.ALL]: 6,
 };
 
 export const URL_TEMPLATES = {
-  CONTENT: (encodedUrl, searchKeyword) =>
+  [SEARCH_MODE.CONTENT]: (encodedUrl, searchKeyword) =>
     `${SERVER_URL}/${encodedUrl}/search?keyword=${searchKeyword}`,
-  TITLE: (encodedUrl, searchKeyword) =>
+  [SEARCH_MODE.TITLE]: (encodedUrl, searchKeyword) =>
     `${SERVER_URL}/title/${encodedUrl}/search?keyword=${searchKeyword}`,
-  ALL: (encodedUrl, searchKeyword) =>
+  [SEARCH_MODE.ALL]: (encodedUrl, searchKeyword) =>
     `${SERVER_URL}/all/${encodedUrl}/search?keyword=${searchKeyword}`,
 };
 
 Object.freeze(SEARCH_MODE);
+Object.freeze(MODE_DESCRIPTION);
+Object.freeze(MODE_EXPECT_CRAWLING_TIME);
 Object.freeze(URL_TEMPLATES);


### PR DESCRIPTION
### 어떤 PR유형인가요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 작업 내용을 요약해주세요
window, mac 운영체제 간 서로 select 태그 디자인이 맞지 않는 호환성을 개선하기 위해 ul, li를 사용한 커스텀 select box를 생성했고,
각 검색 모드 별로 설명문을 추가했습니다.

### 어떻게 보완하면 좋을까요?

### 집중적으로 받고 싶은 피드백은 무엇인가요?
- select list의 bottom 을 px로 조정했는데 이 부분 자세히 봐주시면 감사하겠습니다.
