### PR TITLE
Fix: 검색 시 fetch 요청이 중단되는 문제 해결

### DIFF
--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,4 +1,5 @@
 export const SERVER_URL = "http://localhost:3000/crawl";
+export const STORAGE_LIMIT = 9 * 1024 * 1024;
 
 export const SEARCH_MODE = {
   CONTENT: "내용",

--- a/src/hooks/useFetchUrlContent.js
+++ b/src/hooks/useFetchUrlContent.js
@@ -122,6 +122,7 @@ const useFetchUrlContent = () => {
                   [`${bookmarkItem.url}`]: {
                     ...bookmarkItem,
                     ...allBookmarkList[i],
+                    timestamp: Date.now(),
                   },
                 });
 


### PR DESCRIPTION
### 어떤 PR유형인가요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 작업 내용을 요약해주세요

![Image](https://github.com/user-attachments/assets/d0416da2-2f5e-42a0-bc78-227716937c12)

- saveDataWithStorageCheck()의 while 루프에서 저장공간 확보 과정이 반복되면서 첫 검색 후 fetch요청이 5개만 실행된 후 멈추는 이슈가 있었습니다. 
- while 루프를 제거하고 데이터를 제거하는 함수에서 저장 공간을 확보하는 작업만 처리 후 for문에서 break를 통해 바로 다음 단계로 진행하는 로직으로 개선했습니다.
- 또한, 기존에는 저장 공간이 부족할 경우 반복적으로 삭제 후 저장하는 방식이었으나, 용량이 부족하면 saveDataWithStorageCheck()에서 바로 삭제 후 저장하는 방식으로 변경했습니다.
- STORAGE_LIMIT값을 constants.js로 이동하여 상수를 별도로 관리하도록 개선했습니다.

### 어떻게 보완하면 좋을까요?

- 현재는 정상적으로 실행되는 것을 확인했으나, 특정 환경에서 다시 중단되는 케이스가 발생할 가능성이 있는지 확인하면 좋을 것 같습니다.

### 집중적으로 받고 싶은 피드백은 무엇인가요?

- fetchBookmarkChunk()가 중단되지 않고 정상적으로 실행되는지 추가적인 보완이 필요할지 검토 부탁드립니다.
- 스토리지 공간 확보 및 삭제 로직(`deleteOldestData()`)이 효율적인지 피드백 받고 싶습니다.
