### PR TITLE
fix: 앱 심사를 위해 옵션페이지 화면 에러수정, 크롤링 요청 타임아웃 설정

### DIFF
--- a/options/App.jsx
+++ b/options/App.jsx
@@ -9,6 +9,7 @@ function App() {
 
   const [filteredData, setFilteredData] = useState({ data: [] });
   const [sortedHistory, setSortedHistory] = useState([]);
+  const [searchedList, setSearchedList] = useState([]);
 
   const fetchStorageData = () => {
     chrome.storage.local.get(null, (items) => {
@@ -36,8 +37,8 @@ function App() {
 
       historyArray.sort((a, b) => b.maxTimestamp - a.maxTimestamp);
 
-      setFilteredData(latestItem);
-      setSortedHistory(historyArray);
+      setFilteredData(latestItem || {});
+      setSortedHistory(historyArray || []);
     });
   };
 
@@ -59,6 +60,8 @@ function App() {
         reSearchKeyword,
         setReSearchKeyword,
         setSortedHistory,
+        searchedList,
+        setSearchedList,
         refreshHistory: fetchStorageData,
       }}
     >

--- a/options/components/WebSideSearchHistory.jsx
+++ b/options/components/WebSideSearchHistory.jsx
@@ -48,11 +48,13 @@ export default function WebSideSearchHistory() {
 }
 
 function SearchHistoryBox({ sortedHistory, handleDeleteAndSortHistory }) {
-  const { setFilteredData, setReSearchKeyword } = useContext(WebSearchContext);
+  const { setFilteredData, setReSearchKeyword, setSearchedList } =
+    useContext(WebSearchContext);
 
   const handleShowHistorySearchData = (keyword, innerData) => {
     setReSearchKeyword(keyword);
     setFilteredData(innerData);
+    setSearchedList([keyword]);
   };
 
   return (
@@ -84,6 +86,7 @@ function SearchHistoryBox({ sortedHistory, handleDeleteAndSortHistory }) {
           </p>
         </div>
       ))}
+      {sortedHistory.length === 0 && <p>검색 내역이 없습니다.</p>}
     </>
   );
 }

--- a/options/components/webBottomContent/WebBottomContent.jsx
+++ b/options/components/webBottomContent/WebBottomContent.jsx
@@ -3,25 +3,33 @@ import { useContext } from "react";
 import { WebSearchContext } from "../../context/WebSearchContext";
 
 export default function WebBottomContent() {
-  const { filteredData, searchKeyword, reSearchKeyword } =
+  const { filteredData, searchKeyword, sortedHistory, reSearchKeyword } =
     useContext(WebSearchContext);
-  const changeArrayFilteredData = Object.values(filteredData.data);
+
+  let changeArrayFilteredData = [];
+  if (filteredData.data) {
+    changeArrayFilteredData = Object.values(filteredData.data);
+  }
   const userSearchKeyword = reSearchKeyword ? reSearchKeyword : searchKeyword;
 
   const flattenedItems = changeArrayFilteredData.map(
     (itemObj) => Object.values(itemObj)[0]
   );
-  const totalCount = changeArrayFilteredData.length;
+  const totalCount = changeArrayFilteredData.length || 0;
 
   return (
     <div className="w-full h-[calc(100vh-200px)] overflow-hidden lg:max-w-5xl lg:px-0 md:max-w-screen-md sm:max-w-screen-sm px-2 min-w-[560px]">
-      <p className="pb-2">
-        총 <span className="font-bold">{totalCount}</span> 개의 결과가 검색
-        되었습니다.
-      </p>
+      {totalCount > 0 && (
+        <p className="pb-2">
+          총 <span className="font-bold">{totalCount}</span> 개의 결과가 검색
+          되었습니다.
+        </p>
+      )}
       <div className="w-full overflow-y-auto grid lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-2 gap-4">
         {flattenedItems.map((innerData, index) => (
-          <div
+          <a
+            href={innerData.url}
+            target="_blank"
             className="p-3 bg-white rounded-lg"
             key={index}
           >
@@ -47,9 +55,16 @@ export default function WebBottomContent() {
                   );
                 })}
             </p>
-          </div>
+          </a>
         ))}
       </div>
+      {sortedHistory.length === 0 && (
+        <div className="w-full text-center">
+          <p>
+            저장된 검색내역이 없어요. UrLink 익스텐션에서 먼저 검색해보세요!
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/options/components/webTopContent/top-contents/WebKeywordSearchBox.jsx
+++ b/options/components/webTopContent/top-contents/WebKeywordSearchBox.jsx
@@ -5,13 +5,26 @@ import { useContext, useEffect, useState } from "react";
 import { WebSearchContext } from "../../../context/WebSearchContext";
 
 export default function WebKeywordSearchBox() {
-  const { reSearchKeyword, setReSearchKeyword, filteredData, setFilteredData } =
-    useContext(WebSearchContext);
+  const {
+    reSearchKeyword,
+    setReSearchKeyword,
+    filteredData,
+    setFilteredData,
+    searchedList,
+    setSearchedList,
+  } = useContext(WebSearchContext);
   const [userInputText, setUserInputText] = useState(reSearchKeyword);
 
   useEffect(() => {
     setUserInputText(reSearchKeyword);
-  }, [reSearchKeyword]);
+    setSearchedList((state) => {
+      if (state[state.length - 1] === reSearchKeyword) {
+        return state;
+      } else {
+        return [...state, reSearchKeyword];
+      }
+    });
+  }, [reSearchKeyword, setSearchedList]);
 
   const handleChangeReSearchKeyword = (event) => {
     setUserInputText(event.target.value);
@@ -47,6 +60,7 @@ export default function WebKeywordSearchBox() {
 
   const handleEnterSearch = (event) => {
     if (event.key === "Enter") {
+      event.preventDefault();
       handleReSearchResults();
     }
   };
@@ -57,6 +71,14 @@ export default function WebKeywordSearchBox() {
         <span>Urlink ::</span>
         <span>WEB VIEW</span>
       </h2>
+      <h3 className="mb-1 mx-2 font-bold">
+        {searchedList.length > 0 &&
+          searchedList.map((searched) => {
+            if (searched) {
+              return <span key={searched}>{searched} &gt; </span>;
+            }
+          })}
+      </h3>
       <p className="relative flex-1 h-10 rounded-lg bg-black text-white flex">
         <label
           className="absolute left-0 -z-50 invisible"

--- a/src/components/extensionTopContent/top-contents/GlobalNavigationBar.jsx
+++ b/src/components/extensionTopContent/top-contents/GlobalNavigationBar.jsx
@@ -4,14 +4,15 @@ import { useContext } from "react";
 
 import ExtensionContext from "../../../context/ExtensionContext";
 
-export default function GlobalNavigationBar({ isLoading, inputKeyword }) {
+export default function GlobalNavigationBar({ isLoading }) {
   const { allBookmarkList, searchBookmarkList } = useContext(ExtensionContext);
 
-  const handleOnClickOpenOptionPage = () => {
-    if (chrome.runtime.openOptionsPage && inputKeyword) {
+  const handleOnClickOpenOptionPage = async () => {
+    const hasKeyword = await chrome.storage.local.get(null);
+    if (chrome.runtime.openOptionsPage && Object.keys(hasKeyword).length > 0) {
       chrome.runtime.openOptionsPage();
     } else {
-      alert("키워드 검색 후 열람 할 수 있습니다.");
+      alert("저장된 검색내역이 없어요. 먼저 검색해보세요!");
     }
   };
   <FontAwesomeIcon

--- a/src/hooks/useFetchUrlContent.js
+++ b/src/hooks/useFetchUrlContent.js
@@ -83,7 +83,12 @@ const useFetchUrlContent = () => {
           const fetchUrl = URL_TEMPLATES[searchMode](encodedUrl, searchKeyword);
 
           if (searchKeyword) {
-            return fetch(fetchUrl);
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 7000);
+
+            return fetch(fetchUrl, { signal: controller.signal }).finally(() =>
+              clearTimeout(timeoutId)
+            );
           }
         });
 


### PR DESCRIPTION
### 어떤 PR유형인가요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 작업 내용을 요약해주세요
- 옵션페이지에서 검색 기록이 없을 시 에러가 발생 해 화면이 뜨지 않던 문제를 수정했습니다.
- 옵션페이지 검색 결과 목록에 해당 북마크로 이동할 수 있는 a 태그 설정했습니다.
- 검색 이후 옵션페이지로 가는 순서에서 로컬 스토리지에 검색 기록만 있다면 옵션페이지에 접근 가능하도록 변경했습니다.
- fetch 요청을 개당 최대 7초의 타임아웃을 걸어 서버 메모리를 오래 차지하던 문제를 해결했습니다.

- 신규: 옵션페이지에서 검색 시 검색 순서를 알기 힘들어 검색어를 기록해 어떤 식으로 필터링 되었나 기록하도록 했습니다.
<img width="260" alt="스크린샷 2025-04-11 오후 7 30 19" src="https://github.com/user-attachments/assets/4a0e5825-610c-4e06-a5e1-09e0865603cd" />


